### PR TITLE
ci: Use Travis CI to build and deploy Hugo docs (closes #8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+---
+os: linux
+dist: bionic
+language: go
+go:
+  - 1.14.x
+
+install:
+  - git clone https://github.com/gohugoio/hugo.git
+  - cd hugo
+  - go install
+
+script: hugo
+
+deploy:
+  committer_from_gh: true
+  local_dir: public/
+  provider: pages
+  skip_cleanup: true
+  token: "$GITHUB_TOKEN"
+  on:
+    branch: master
+
+env:
+  global:
+    secure: jImZF7z6hXVuUKKDXsP5FdMXR7APSOUwdz+SQ9zE9VRJVNiEAf9O8tLSWjIc1lpBxR/ADcsKIGvY0lzI6srJn/ULYXKmZ5xoxlpLw/kZxSfjXNVf7eZWfiw7dQUVB4YvdbUEwAtExO91xDEL536UKQ9VVqPfVty840ZTbn+Mkbo1P1CocD3gfruSVsPEHotHNz0O2p6IqNgdRB+2v0r0C5lP/Cpwg+E1j9lcL6jR+KmgB7waW6blzdIovtTPBhtr1zdFDNd/1WpIQFUW2iYjYCFgKKtcTsNV2Z6VWfaX0F2/n7t0mTvl6Rv9jgAlVk0R8Z9C9B2NUfpZU1UqKiIiTSTShDxbxqdAP7mU+xMI1SI22MRdRCir/N1xRGoaH5u1wiSQkA/dpuAnZqht0pygdkKgaW7UFrEg1rgCt7hJ9xw0LpFz7X0NJOAP/5QOudjk4Pot4xl2N4MgOmRrdAuOhgMHTk0b0l1yjNPzDZTuwgWV15z9nHUynI5kLXs+S6D2DMXa9aZBfr273qM5EhKxhc7ZmIGlbdbmIEQss/70Y7s8r9VD9WhaaIVzeMO9pIAmwLyEZ15jsLzyglmFkjpWfvi/hqXaL+Ly59uGXaiidRz75xGfozVIj+oYXS7wwVFza8QzaNuJe4HRo0sP49UM8KZkpQfi9rjeSbET1ukCLL8=

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 baseURL = "https://librecorps.github.io/resources/"
 theme = "dot-hugo-documentation-theme"
-publishDir = "docs"
 defaultContentLanguage = "en"
 home = "/"
 
@@ -26,17 +25,17 @@ whiteColor = "#ffffff"
 
     # navigation
     [Languages.en.menu]
-    
+
       [[Languages.en.menu.main]]
         weight = 2
         name = "Faq"
         url = "faq"
-        
+
       [[Languages.en.menu.main]]
         weight = 2
         name = "contact"
         url = "contact"
-        
+
       [[Languages.en.menu.main]]
         weight = 2
         name = "pages"
@@ -92,7 +91,7 @@ whiteColor = "#ffffff"
     # Topics
     [Languages.en.params.topics]
       title = "Find your answer by subject"
-    
+
     # call to action
     [Languages.en.params.cta]
       enable = true
@@ -114,11 +113,11 @@ whiteColor = "#ffffff"
     [[Languages.en.socialIcon]]
       icon = "ti-twitter-alt"
       linkURL = "#"
-      
+
     [[Languages.en.socialIcon]]
       icon = "ti-vimeo-alt"
       linkURL = "#"
-      
+
     [[Languages.en.socialIcon]]
       icon = "ti-instagram"
       linkURL = "#"


### PR DESCRIPTION
This commit sets up a Travis CI config that installs Hugo into the build
environment, builds our docs, and if the test runs on the `master`
branch, it will push the built assets to a `gh-pages` branch on the
librecorps/resources repo. Once this commit is merged, we can switch
over the build settings to use that branch to serve our docs.

Closes #8.