### PR TITLE
ci: Rework Hugo extraction logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,25 @@ os: linux
 dist: bionic
 language: go
 go:
-  - 1.14.x
+  - "1.14.x"
 
-install:
-  - git clone https://github.com/gohugoio/hugo.git
-  - cd hugo
-  - go install
+# Download a specific version of the Hugo release tarball, extract the `hugo`
+# binary from the tarball to $GOPATH/bin so it is executable in the build env
+install: "curl --location https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar -xvz --directory=$(go env GOPATH)/bin hugo"
 
 script: hugo
 
 deploy:
   committer_from_gh: true
-  local_dir: public/
+  local_dir: "public/"
   provider: pages
   skip_cleanup: true
+  target_branch: gh-pages
   token: "$GITHUB_TOKEN"
   on:
     branch: master
 
 env:
   global:
-    secure: jImZF7z6hXVuUKKDXsP5FdMXR7APSOUwdz+SQ9zE9VRJVNiEAf9O8tLSWjIc1lpBxR/ADcsKIGvY0lzI6srJn/ULYXKmZ5xoxlpLw/kZxSfjXNVf7eZWfiw7dQUVB4YvdbUEwAtExO91xDEL536UKQ9VVqPfVty840ZTbn+Mkbo1P1CocD3gfruSVsPEHotHNz0O2p6IqNgdRB+2v0r0C5lP/Cpwg+E1j9lcL6jR+KmgB7waW6blzdIovtTPBhtr1zdFDNd/1WpIQFUW2iYjYCFgKKtcTsNV2Z6VWfaX0F2/n7t0mTvl6Rv9jgAlVk0R8Z9C9B2NUfpZU1UqKiIiTSTShDxbxqdAP7mU+xMI1SI22MRdRCir/N1xRGoaH5u1wiSQkA/dpuAnZqht0pygdkKgaW7UFrEg1rgCt7hJ9xw0LpFz7X0NJOAP/5QOudjk4Pot4xl2N4MgOmRrdAuOhgMHTk0b0l1yjNPzDZTuwgWV15z9nHUynI5kLXs+S6D2DMXa9aZBfr273qM5EhKxhc7ZmIGlbdbmIEQss/70Y7s8r9VD9WhaaIVzeMO9pIAmwLyEZ15jsLzyglmFkjpWfvi/hqXaL+Ly59uGXaiidRz75xGfozVIj+oYXS7wwVFza8QzaNuJe4HRo0sP49UM8KZkpQfi9rjeSbET1ukCLL8=
+    - HUGO_VERSION: "0.67.1"
+    - secure: "jImZF7z6hXVuUKKDXsP5FdMXR7APSOUwdz+SQ9zE9VRJVNiEAf9O8tLSWjIc1lpBxR/ADcsKIGvY0lzI6srJn/ULYXKmZ5xoxlpLw/kZxSfjXNVf7eZWfiw7dQUVB4YvdbUEwAtExO91xDEL536UKQ9VVqPfVty840ZTbn+Mkbo1P1CocD3gfruSVsPEHotHNz0O2p6IqNgdRB+2v0r0C5lP/Cpwg+E1j9lcL6jR+KmgB7waW6blzdIovtTPBhtr1zdFDNd/1WpIQFUW2iYjYCFgKKtcTsNV2Z6VWfaX0F2/n7t0mTvl6Rv9jgAlVk0R8Z9C9B2NUfpZU1UqKiIiTSTShDxbxqdAP7mU+xMI1SI22MRdRCir/N1xRGoaH5u1wiSQkA/dpuAnZqht0pygdkKgaW7UFrEg1rgCt7hJ9xw0LpFz7X0NJOAP/5QOudjk4Pot4xl2N4MgOmRrdAuOhgMHTk0b0l1yjNPzDZTuwgWV15z9nHUynI5kLXs+S6D2DMXa9aZBfr273qM5EhKxhc7ZmIGlbdbmIEQss/70Y7s8r9VD9WhaaIVzeMO9pIAmwLyEZ15jsLzyglmFkjpWfvi/hqXaL+Ly59uGXaiidRz75xGfozVIj+oYXS7wwVFza8QzaNuJe4HRo0sP49UM8KZkpQfi9rjeSbET1ukCLL8="


### PR DESCRIPTION
This change is a little complex, so it is broken down below:

* **Problem**: Previous way cloned hugo from GitHub, changed directories
  into git clone, installed hugo, then built hugo docs from the git
  clone, not our docs
* **Solution**: Download compiled binary from upstream repo (to save
  time on compiling), extract to `$GOPATH/bin`, and never change
  directories
* **Impact**: Hugo builds our docs, not whatever is inside the Hugo git
  clone from GitHub :sweat_smile:

This fixes the deploy step, so Travis should be able to add the built
static pages and deploy it on the `gh-pages` branch.