### PR TITLE
Enable git timestamps and emoji

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,8 @@
 baseURL = "https://librecorps.github.io/resources/"
 theme = "dot"
 title = "LibreCorps Resources"
+enableEmoji = true
+enableGitInfo = true
 
 [markup.goldmark.renderer]
 unsafe = true


### PR DESCRIPTION
Two minor tweaks to the config file:

1. Enable emojis: In case we want to make our content more :laugh:
2. Enable `.gitInfo` on pages: Instead of manually updating the
   timestamp when a page is updated, use the data from git to
   automatically tell what day the page was last updated. Way smarter!