### PR TITLE
Reading lists: Break up into smaller docs

### DIFF
--- a/content/community/reading-list.md
+++ b/content/community/reading-list.md
@@ -1,55 +1,37 @@
 ---
-title: "Open Source Reading List"
-date: 2019-09-03T11:02:05+06:00
+title: "Open communities reading list"
+date: 2020-03-25
 type: "post"
-weight : 2
+weight: 10
 ---
-**Introduction to FOSS**
 
-- [Open Source Guides](https://opensource.guide/)_GitHub.com_
-
-- [Introduction to Open Source](https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source)_Digital Ocean_
-
-- [FAQ in FOSS](https://opensource.com/resources)_Opensource.com_
-
-**Project Management**
-
-- [Why (some) agile teams fail](https://opensource.com/article/18/6/agile-vision-consider) - _Jen Krieger_ [_@mrry550_](https://github.com/mrry550)
-
-- [How we organize GitHub issues: A simple styleguide for tagging](https://robinpowered.com/blog/best-practice-system-for-organizing-and-tagging-github-issues/) - _Zach Dunn_ [_@zachdunn_](https://github.com/zachdunn)
-
-**Documentation**
-
-- [Your step-by-step guide to more effective documentation](https://opensource.com/open-organization/17/10/readme-maturity-model) - _Lauri Apple_ [_@LappleApple_](https://github.com/LappleApple)
-
-- [A template for creating open source contributor guidelines](https://opensource.com/life/16/3/contributor-guidelines-template-and-tips) - _Safia Abdalla_ [_@captainsafia_](https://github.com/captainsafia)
-
-- [CONTRIBUTING-template.md](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md) - _Nadia Eghbal_ [_@nayafia_](https://github.com/nayafia)
-
-**Continuous Integration and Health Checks**
-
-- [Continuous Integration Essentials](https://codeship.com/continuous-integration-essentials)_Codeship_
-
-Workflow
-
-- (_video_) [Have It Your Way: Maximizing Drive-Thru Contributions](https://archive.org/details/ato2017-drivethru) - _VM Brasseur_ [_@vmbrasseur_](https://github.com/vmbrasseur)
-
-**Community Outreach**
-
-- [What success really looks like in open source](https://medium.com/@nayafia/what-success-really-looks-like-in-open-source-2dd1facaf91c) - _Nadia Eghbal_ [_@nayafia_](https://github.com/nayafia)
-
-**FOSS Product Development**
-
-- [Setting an Open Source Strategy](https://www.linuxfoundation.org/resources/open-source-guides/setting-an-open-source-strategy/) - Linux Foundation
-
-- [A Free Guide for Setting Your Open Source Strategy](https://www.linuxfoundation.org/blog/2018/11/a-free-guide-for-setting-your-open-source-strategy/) - Linux Foundation
-
-- [6 steps to perfecting an open source product strategy](https://opensource.com/article/17/9/demystifying-open-source-product-strategy) - [Michael DeHaan](https://twitter.com/laserllama) @ opensource.com
-
-- [Producing Open Source Software](https://producingoss.com/en/index.html) by Karl Fogel ( **has resources on all major topics here** )
+This page is a collection of resources around open source community management and strategy.
+It is a catch-all reading list for anything related to supporting the people and humans behind the open source projects.
+If you are familiar with the role of a developer advocate, there is some overlap between the responsibilities of that type of position.
 
 
+## Foundations
 
-**Additional Readings:**
+* [Open Source Guides](https://opensource.guide/) - _curated by GitHub_
+    * Covers a broad range of topics and concepts to allow you to focus in on specific areas
+* [Introduction to Open Source](https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source) - _Digital Ocean_
+* [Frequently asked questions about open source](https://opensource.com/resources) - _Opensource.com_
 
-- [Forge Your Future with Open Source](https://fossforge.com/) by [_@vmbrasseur_](https://github.com/vmbrasseur) This is a great peer-reviewed book about building and growing FOSS projects and a community around the project. It is behind a paywall.
+
+## Documentation
+
+* [Your step-by-step guide to more effective documentation](https://opensource.com/open-organization/17/10/readme-maturity-model) - _Lauri Apple [@LappleApple](https://github.com/LappleApple)_
+* [A template for creating open source contributor guidelines](https://opensource.com/life/16/3/contributor-guidelines-template-and-tips) - _Safia Abdalla [@captainsafia](https://github.com/captainsafia)_
+* [CONTRIBUTING-template.md](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md) - _Nadia Eghbal [@nayafia](https://github.com/nayafia)_
+
+
+## Workflow
+
+* (_video_) [Have It Your Way: Maximizing Drive-Thru Contributions](https://archive.org/details/ato2017-drivethru) - _VM Brasseur [@vmbrasseur](https://github.com/vmbrasseur)_
+
+
+## Additional readings
+
+* (_book_) [Forge Your Future with Open Source](https://fossforge.com/) - _VM Brasseur [@vmbrasseur](https://github.com/vmbrasseur)_
+    * This is an excellent peer-reviewed book about building and growing FOSS projects and a community around the project.
+      It is well worth the $20 USD cost.

--- a/content/hardware/reading-list.md
+++ b/content/hardware/reading-list.md
@@ -1,0 +1,7 @@
+---
+title: "Open Hardware reading list"
+date: 2020-03-25
+type: "post"
+weight: 10
+---
+

--- a/content/legal/reading-list.md
+++ b/content/legal/reading-list.md
@@ -1,0 +1,31 @@
+---
+title: "Legal and business reading list"
+date: 2020-03-25
+type: "post"
+weight: 10
+---
+
+This reading list is a collection of resources on legal and business aspects of open source.
+Legal and business aspects of an open source project are part of the foundation for building your project and community.
+The resources linked here are intended to give you a better idea of open source from a legal perspective.
+
+
+## Foundations
+
+* [The Open Source Definition (Annotated)](https://opensource.org/osd-annotated) - _Open Source Initiative_
+* [Open Source Licenses by Name](https://opensource.org/licenses/alphabetical) - _Open Source Initiative_
+
+
+## Choosing a license
+
+* [Choose an open source license](https://choosealicense.com/) - _curated by GitHub_
+* [TLDRLegal - Software licenses explained in plain English](https://tldrlegal.com/) - _FOSSA, Inc_
+
+
+## License examples
+
+* [OpenStreetMap - Copyright and License](https://www.openstreetmap.org/copyright) - _OpenStreetMap_
+    * Good example of a project with an open data license
+* Open Data Commons Open Database License (ODbL)
+    * [Overview](https://opendatacommons.org/licenses/odbl/)
+    * [Human-readable summary](https://opendatacommons.org/licenses/odbl/summary/)

--- a/content/outreach/reading-list.md
+++ b/content/outreach/reading-list.md
@@ -1,0 +1,12 @@
+---
+title: "Community outreach reading list"
+date: 2020-03-25
+type: "post"
+weight: 10
+---
+
+This reading list focuses on ways to promote and share your open source project with the world.
+Generally these resources are more helpful once you have built up the foundation for your open source project.
+You should have a game plan for community management in place before spending a lot of time on outreach.
+
+* [What success really looks like in open source](https://medium.com/@nayafia/what-success-really-looks-like-in-open-source-2dd1facaf91c) - _Nadia Eghbal [@nayafia](https://github.com/nayafia)_

--- a/content/product-management/reading-list.md
+++ b/content/product-management/reading-list.md
@@ -1,0 +1,27 @@
+---
+title: "Project management reading list"
+date: 2020-03-25
+type: "post"
+weight: 10
+---
+
+This is a reading list of resources around project management and product development.
+While there are many resources on these topics around the web, this reading list focuses specifically on an open source perspective.
+
+
+## Defining strategy
+
+* [6 steps to perfecting an open source product strategy](https://opensource.com/article/17/9/demystifying-open-source-product-strategy) - _[Michael DeHaan](https://twitter.com/laserllama)_
+* [A Free Guide for Setting Your Open Source Strategy](https://www.linuxfoundation.org/blog/2018/11/a-free-guide-for-setting-your-open-source-strategy/) - _Linux Foundation_
+* [Producing Open Source Software](https://producingoss.com/) - _Karl Fogel_ (**includes resources on almost all major topics**)
+* [Setting an Open Source Strategy](https://www.linuxfoundation.org/resources/open-source-guides/setting-an-open-source-strategy/) - _Linux Foundation_
+
+
+## Managing in the open
+
+* [How we organize GitHub issues: A simple styleguide for tagging](https://robinpowered.com/blog/best-practice-system-for-organizing-and-tagging-github-issues/) - _Zach Dunn [@zachdunn](https://github.com/zachdunn)_
+
+
+## Methodologies
+
+* [Why (some) agile teams fail](https://opensource.com/article/18/6/agile-vision-consider) - _Jen Krieger [@mrry550](https://github.com/mrry550)_

--- a/content/tooling/reading-list.md
+++ b/content/tooling/reading-list.md
@@ -1,0 +1,16 @@
+---
+title: "Tooling and automation reading list"
+date: 2020-03-25
+type: "post"
+weight: 10
+---
+
+This reading list is focused on recommending specific tools and services for building your open source project.
+Remember, the resources linked here are subjective.
+Some tools that work for some projects won't work for others.
+This page is a resource to help you launch into your own independent research.
+
+
+## Continuous integration (CI)
+
+* [Continuous Integration Essentials](https://codeship.com/continuous-integration-essentials) - _Codeship_


### PR DESCRIPTION
This commit divides up the monolithic, multi-topic reading list that was
once in the `content/community/reading-list.md` file into reading lists
in each category. This groups relevant content from the monolithic
reading list into the existing category structure on the site. It makes
our reading lists less wieldy and a little easier to navigate.