### PR TITLE
WIP: Add Open Hardware research draft

### DIFF
--- a/content/hardware/research.md
+++ b/content/hardware/research.md
@@ -1,0 +1,62 @@
+---
+title: "Work in progress: Open Hardware research"
+date: 2020-03-25
+type: "post"
+weight: 20
+draft: true
+---
+
+This is a draft page.
+While it can exist in the source repo, it will not be visible on the main site until `draft: true` is removed.
+
+
+## Readings
+
+* [Why public institutions should release more of their hardware designs as Open-Source Hardware](https://forum.openhardware.science/t/why-public-institutions-should-release-more-of-their-hardware-designs-as-open-source-hardware/2235): opinion article from the open hardware initiator at CERN, Javier Serrano, gives a good overview of the current situation
+* Free Innovation by Eric von Hippel: https://mitpress.mit.edu/books/free-innovation
+* [How participative is open source hardware? Insights from online repository mining](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/D1341B4E550B8F42032585694B6DB8D8/S205347011800015Xa.pdf/how_participative_is_open_source_hardware_insights_from_online_repository_mining.pdf)
+    * interesting study of how people work together (or governance even if it's not designed)
+    * (there is so, so little info on governance for open hw that I think it's *so* important for the discussion to start)
+* [Emerging Business Models for Open Source Hardware](https://openhardware.metajnl.com/articles/10.5334/joh.4/): many ideas on open hardware business models (more specifically for science but it's good food for thought)
+* [Measuring Openness in Open Source Hardware with the Open-o-Meter](https://www.sciencedirect.com/science/article/pii/S2212827118312095?via%3Dihub)
+* [Open HW refs in Zotero (may be a bit messy)](https://www.zotero.org/groups/2312397/open_hardware/library)
+* [Collaborative list of open hw resources](https://github.com/Open-Hardware-Leaders/Resources): This is the nirvana of open information on Open Hardware :heart:
+
+
+## Example projects
+
+* opentrons (has also raised VC funding)
+* adafruit
+* sparkfun
+* openROV
+* farmbot
+* IoRodeo
+* Ultimaker
+* Prusa research
+* Backyard Brains
+* Seeed Studio
+* Sanworks
+* Open Ephys
+* Safecast
+* OpenBCI
+* OLIMEX
+* Arduino
+* World Famous Electronics, maker of the [Pulse Sensor](http://www.pulsesensor.com/)
+    * This company has not ever applied for funding besides the startup crowdfunding campaign that launched us
+* list of certified hardware at www.owshwa.org https://certification.oshwa.org/list.html
+* Aleph Objects, makers of Lulz Bot family of 3D printers
+* risc-v: https://riscv.org/risc-v-history/
+
+
+## Research contributors
+
+Names of people I need to attribute for their support in creating this research (probably should go index page):
+
+* André Maia Chagas
+* Joel Murphy
+* Julieta Arancio
+* Emilio Velis
+* Addie Wagenknecht
+* Jose Urra
+* Alexander Kutschera
+* Andrew Lamb


### PR DESCRIPTION
This commit adds a brain-dump of all the content collected from our
network of Open Hardware folks who have given us advice and pointers on
how to navigate the Open Hardware space. Currently it is massively
disorganized and mostly just a list of "things".

One of the things I now love about Hugo is I marked this page as a
"draft". So, I can get this stuff out of my head and into `git` without
it being published in our docs site. If you run `hugo server -D`
locally, you can generate a version of the site with this page included.
But in the production environment on GitHub Pages, this page will not
exist. Hooray! :tada:

I really needed to get this down somewhere because I keep putting it off
since it is a lot of work. But this will make it easier for me to
iterate on something and hopefully turn it into something more
meaningful in the next few days.

![Screenshot from local preview](https://user-images.githubusercontent.com/4721034/77589085-73470880-6ec1-11ea-8a66-a57a8a950acf.png "Screenshot from local preview")